### PR TITLE
Fix issue that tax is not computed if string is empty

### DIFF
--- a/invoice-maker.typ
+++ b/invoice-maker.typ
@@ -382,7 +382,7 @@
       else { panic(["#discount.type" is no valid discount type]) }
     }
   let has-reverse-charge = {
-        biller.vat-id.slice(0, 2) != recipient.vat-id.slice(0, 2)
+        biller.vat-id != recipient.vat-id.slice
       }
   let tax = if has-reverse-charge { 0 } else { sub-total * vat }
   let total = sub-total - discount-value + tax


### PR DESCRIPTION
Hi there,

Thanks for making this template and working on a replacement for Latex. I have had my eye on this project for a while but this was the first time using it. I noticed that when making the invoice my reverse charge was not compute if one of the two strings for vat-id was empty. In my case one of the parties does not have a vat-id. This replaces the logic to check if the strings are not equal which is the intention (I guess) in the first place.

Cheers! C